### PR TITLE
fixing/properly implementing some tests for coroutine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ python:
 install:
   - pip install -r requirements-dev.txt
 
+services:
+  - memcached
+
 script:
   - make lint test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Asyncio-Toolkit Changelog
 ==============
 
-### [NEXT_RELEASE] ### [0.1.2] - 2017-08-29 ### [0.1.1] - 2017-08-22
+### [NEXT_RELEASE] 
+
+#### Fixed
+
+* Tests added to asyncio.coroutine style calls
+
+### [0.1.2] - 2017-08-29 
+
+#### Fixed
+
+* Uncatched exceptions that were not being raised
+
+### [0.1.1] - 2017-08-22
 
 * First release (supporting usage as a context and as a coroutine)

--- a/asyncio_toolkit/circuit_breaker/coroutine.py
+++ b/asyncio_toolkit/circuit_breaker/coroutine.py
@@ -38,7 +38,7 @@ class circuit_breaker(BaseCircuitBreaker):
             )
         )
 
-        return (yield from self.storage.get(key) or 0)
+        return int((yield from self.storage.get(key) or 0))
 
     @property
     @asyncio.coroutine

--- a/conftest.py
+++ b/conftest.py
@@ -5,11 +5,9 @@ import pytest
 
 @pytest.fixture(scope='session')
 def loop():
-    # Set-up
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
+    return asyncio.get_event_loop()
 
-    loop.run_until_complete()
 
-    # Clean-up
-    loop.close()
+@pytest.fixture
+def run_sync(loop):
+    return loop.run_until_complete


### PR DESCRIPTION
 Description: Fixing broken coroutine tests as issued here: #9 

I've did the tests this way because it seemed less weird to run it synchronously inside the loop, instead of setting up a bunch of things just to make the yields work properly. And as this project currently aims to add support to `asyncio.coroutine` style calls, it seems to me that this is a reasonable choice; but if anyone knows how to make this work properly AND to meet the multiple syntaxes criteria, I'd be _really very welcome and happy_ to listen to =)

 ### Checklist:
 - [x] Tests
 - [x] Changelog
