### PR TITLE
Raise catchable exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.6"
 
 install:
+  - pip install -U setuptools pip wheel
   - pip install -r requirements-dev.txt
 
 services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 Asyncio-Toolkit Changelog
 ==============
 
-### [NEXT_RELEASE] ### [0.2.2] - 2017-11-16
+### [NEXT_RELEASE] 
+#### Fixed
+* raise catchable exception
+
+### [0.2.2] - 2017-11-16
 
 #### Fixed
 

--- a/asyncio_toolkit/circuit_breaker/coroutine.py
+++ b/asyncio_toolkit/circuit_breaker/coroutine.py
@@ -79,6 +79,7 @@ class circuit_breaker(BaseCircuitBreaker):
                         )
 
                         raise self.max_failure_exception
+                    raise e
                 else:
                     raise e
 

--- a/tests/circuit_breaker/test_coroutine_circuit_breaker.py
+++ b/tests/circuit_breaker/test_coroutine_circuit_breaker.py
@@ -202,3 +202,23 @@ class TestCoroutineCircuitBreaker:
 
         count = get_failure_count(request, run_sync)
         assert count == 999
+
+    @pytest.mark.parametrize(
+        'fail_example_fixture,set_failure_count',
+        [
+            ('fail_example_async', set_failure_count_memcached),
+            ('fail_example_memcached', set_failure_count_memcached),
+            ('fail_example_redis', set_failure_count_redis),
+        ]
+    )
+    def test_catched_error_is_raised_when_max_failures_are_not_exceeded(
+        self,
+        request,
+        fail_example_fixture,
+        set_failure_count,
+        run_sync,
+        flush_cache
+    ):
+        fail_example = request.getfuncargvalue(fail_example_fixture)
+        with pytest.raises(ValueError):
+            run_sync(fail_example())


### PR DESCRIPTION
 **Description**:
Como a o tratamento do cb está sendo feito no `__call__` o cb está capturando a exception original(que o app passa no `catchable`) e não está deixando ela ser lançada. As unicas exceções lançadas da forma que está seriam a `max_failure` e a Exeption capturada(caso não fosse passada pelo app). 

Só estou adicionando o `raise` pra subir a exceção original. 

 ### Checklist:
 - [x] Tests
 - [x] Changelog
 - [ ] Docs
