### PR TITLE
Update aiocache lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 Asyncio-Toolkit Changelog
-==============
+=========================
 
-### [NEXT_RELEASE] ### [0.2.3] - 2019-01-24 
+### [NEXT_RELEASE]
+
+#### Updated
+
+* aiocache version
+
+### [0.2.3] - 2019-01-24
+
 #### Fixed
+
 * raise catchable exception
 
 ### [0.2.2] - 2017-11-16
@@ -17,7 +25,7 @@ Asyncio-Toolkit Changelog
 
 * deleting cache number of failures when opening circuit breaker
 
-### [0.2.0] - 2017-10-18 
+### [0.2.0] - 2017-10-18
 
 ### Added
 
@@ -27,7 +35,7 @@ Asyncio-Toolkit Changelog
 
 * Tests added to asyncio.coroutine style calls
 
-### [0.1.2] - 2017-08-29 
+### [0.1.2] - 2017-08-29
 
 #### Fixed
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,6 @@ mkdocs==0.16.3
 pytest-cov==2.5.1
 pytest==3.2.0
 werkzeug==0.12.2
-aiocache==0.7.2
-aiomcache==0.3.0
+aiocache==0.11.1
+aiomcache==0.6.0
+aioredis==1.3.0


### PR DESCRIPTION
Description: The current version of aiocache library has problems with setuptools and broken the local installation. The following stacktrace was captured and show the problem:

```
ERROR: Command errored out with exit status 1:
     command: /home/luiz/.virtualenvs/asyncio-toolkit/bin/python3.7 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-czyz7sic/aiocache/setup.py'"'"'; __file__='"'"'/tmp/pip-install-czyz7sic/aiocache/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-czyz7sic/aiocache/pip-egg-info
         cwd: /tmp/pip-install-czyz7sic/aiocache/
    Complete output (1 lines):
    error in aiocache setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Unordered types are not allowed
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

The current changes just update aiocache and add aioredis to fix tests with new version.

 ### Checklist:
 - [x] Tests
 - [x] Changelog
 - [ ] Docs
