### PR TITLE
Fix failures timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Asyncio-Toolkit Changelog
 
 * aiocache version
 
+#### Fixed
+
+* timeout of failures counter
+
 ### [0.2.3] - 2019-01-24
 
 #### Fixed

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ lint:  ## Run static code checks
 test: clean ## Run unit tests
 	@py.test -xs tests/
 
+test-matching: clean ## Search and run unit test
+	@py.test -xs tests/ -k $(Q)
+
 coverage:  ## Run unit tests and generate code coverage report
 	@py.test -xs --cov asyncio_toolkit/ --cov-report=xml --cov-report=term-missing tests/
 

--- a/asyncio_toolkit/circuit_breaker/context_manager.py
+++ b/asyncio_toolkit/circuit_breaker/context_manager.py
@@ -16,6 +16,18 @@ class CircuitBreaker(BaseCircuitBreaker):
         getting a storage key from the storage engine.
         """
         total = self.storage.increment(self.failure_key)
+        if total == 1:
+            logger.debug(
+                'Starting failure window for: {key} - '
+                'timeout: {timeout}'.format(
+                    key=self.failure_key,
+                    timeout=self.max_failure_timeout
+                )
+            )
+            self.storage.expire(
+                self.failure_key,
+                self.max_failure_timeout
+            )
 
         logger.info(
             'Increase failure for: {key} - '

--- a/asyncio_toolkit/circuit_breaker/coroutine.py
+++ b/asyncio_toolkit/circuit_breaker/coroutine.py
@@ -18,8 +18,20 @@ class circuit_breaker(BaseCircuitBreaker):
         This method demands that the implementation is responsible for
         getting a storage key from the storage engine.
         """
-
         total = yield from self.storage.increment(self.failure_key, 1)
+        if total == 1:
+            logger.debug(
+                'Starting failure window for: {key} - '
+                'timeout: {timeout}'.format(
+                    key=self.failure_key,
+                    timeout=self.max_failure_timeout
+                )
+            )
+            yield from self.storage.expire(
+                self.failure_key,
+                self.max_failure_timeout
+            )
+
         logger.info(
             'Increase failure for: {key} - '
             'max failures {max_failures} - '

--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,12 @@
 import asyncio
 
 import pytest
-from aiocache import MemcachedCache, RedisCache
 
-from asyncio_toolkit.circuit_breaker.storage import MemoryStorage
+from tests.factory import (
+    create_memcached_instance,
+    create_memory_instance,
+    create_redis_instance
+)
 
 
 @pytest.fixture(scope='session')
@@ -18,21 +21,14 @@ def run_sync(loop):
 
 @pytest.fixture
 def memcached():
-    return MemcachedCache(
-        endpoint='127.0.0.1',
-        port=11211,
-        loop=asyncio.get_event_loop()
-    )
+    return create_memcached_instance()
 
 
 @pytest.fixture
 def redis(run_sync):
-    return RedisCache(
-        endpoint='127.0.0.1',
-        port=6379
-    )
+    return create_redis_instance()
 
 
 @pytest.fixture
 def memory():
-    return MemoryStorage()
+    return create_memory_instance()

--- a/tests/circuit_breaker/test_storage.py
+++ b/tests/circuit_breaker/test_storage.py
@@ -1,0 +1,54 @@
+import time
+
+from asyncio_toolkit.circuit_breaker.storage import MemoryStorage
+
+
+class TestMemoryStorage:
+
+    def test_get_found(self):
+        storage = MemoryStorage()
+        key = 'some_key'
+        value = 'some_data'
+        storage.set(key, value, 2)
+        result = storage.get(key)
+        assert result == value
+
+    def test_get_not_found(self):
+        storage = MemoryStorage()
+        result = storage.get('some_key')
+        assert result is None
+
+    def test_get_timeout_exceeded(self):
+        storage = MemoryStorage()
+        key = 'some_key'
+        storage.set(key, 'some_data', 2)
+        storage._timeout = {key: time.time() - 1}
+        result = storage.get(key)
+        assert result is None
+
+    def test_increment(self):
+        storage = MemoryStorage()
+        key = 'some_key'
+        storage.increment(key)
+        result = storage.get(key)
+        assert result == 1
+
+    def test_set(self):
+        storage = MemoryStorage()
+        key = 'some_key'
+        value = 'some_data'
+        storage.set(key, value, 2)
+        result = storage.get(key)
+        assert result == value
+
+    def test_expire(self):
+        storage = MemoryStorage()
+        key = 'some_key'
+        storage.expire(key, 2)
+        assert key in storage._timeout
+
+    def test_expire_with_none_timeout(self):
+        storage = MemoryStorage()
+        key = 'some_key'
+        storage.expire(key, None)
+        assert not storage._timeout

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -1,0 +1,24 @@
+import asyncio
+
+from aiocache import MemcachedCache, RedisCache
+
+from asyncio_toolkit.circuit_breaker.storage import MemoryStorage
+
+
+def create_memcached_instance():
+    return MemcachedCache(
+        endpoint='127.0.0.1',
+        port=11211,
+        loop=asyncio.get_event_loop()
+    )
+
+
+def create_redis_instance():
+    return RedisCache(
+        endpoint='127.0.0.1',
+        port=6379
+    )
+
+
+def create_memory_instance():
+    return MemoryStorage()


### PR DESCRIPTION
Description: Currently, when a error is recorded in circuit breaker, the errors counter don't have a timeout to expire and define a time window to analyse the number of erros through the time. In this case, the CB will ever open because the number of errors is reached all times, sooner or later. The changes proposed in this PR set a timeout for errors counter using configuration `max_failure_timeout`, that don't have a previous function to configure CB.

 ### Checklist:
 - [x] Tests
 - [x] Changelog
 - [ ] Docs
